### PR TITLE
fix: image and text overflowing on the issues page

### DIFF
--- a/src/components/Home/IssueCard.tsx
+++ b/src/components/Home/IssueCard.tsx
@@ -48,7 +48,15 @@ const IssueCard: FC<IssueCardProps> = ({
 					/>
 				</Typography>
 				<Divider />
-				<Typography p={2}>
+				<Typography
+					p={2}
+					sx={{
+						wordBreak: 'break-word',
+						img: {
+							width: '100%',
+						}
+					}}
+				>
 					<ReactMarkdown>{body}</ReactMarkdown>
 				</Typography>
 				<GitHubButton


### PR DESCRIPTION
Fixes #17 


![localhost_3000_](https://user-images.githubusercontent.com/41188167/196517608-e56786f6-8734-41fd-9c7f-203af29a82fc.png)

<img width="916" alt="Screenshot 2022-10-18 at 11 39 32 PM" src="https://user-images.githubusercontent.com/41188167/196517635-97838bc0-b1a6-46f9-96eb-2d662e53dc85.png">
